### PR TITLE
feat(package): include non-minified build and use as package.main

### DIFF
--- a/webpack.config.dist.js
+++ b/webpack.config.dist.js
@@ -1,32 +1,39 @@
 /* eslint-env node */
 const path = require('path')
 
-module.exports = {
-  mode: 'production',
-  devtool: 'source-map',
-  entry: [require.resolve('./src/sweetalert2-react-content')],
-  output: {
-    library: 'sweetalert2ReactContent',
-    libraryTarget: 'umd',
-    path: path.resolve(__dirname, 'dist'),
-    filename: 'sweetalert2-react-content.umd.js',
-  },
-  module: {
-    strictExportPresence: true,
-    rules: [
-      {
-        test: /\.js$/,
-        exclude: /node_modules/,
-        loader: require.resolve('babel-loader'),
-        options: {},
-      },
-    ],
-  },
-  externals: expandExternalsConfig({
-    react: 'React',
-    'react-dom': 'ReactDOM',
-    sweetalert2: 'swal',
-  }),
+module.exports = [
+  getWebpackConfig({ minify: true }),
+  getWebpackConfig({ minify: false }),
+]
+
+function getWebpackConfig({ minify }) {
+  return {
+    mode: minify ? 'production' : 'development',
+    devtool: 'source-map',
+    entry: [require.resolve('./src/sweetalert2-react-content')],
+    output: {
+      library: 'sweetalert2ReactContent',
+      libraryTarget: 'umd',
+      path: path.resolve(__dirname, 'dist'),
+      filename: `sweetalert2-react-content.${minify ? 'umd.min' : 'umd'}.js`,
+    },
+    module: {
+      strictExportPresence: true,
+      rules: [
+        {
+          test: /\.js$/,
+          exclude: /node_modules/,
+          loader: require.resolve('babel-loader'),
+          options: {},
+        },
+      ],
+    },
+    externals: expandExternalsConfig({
+      react: 'React',
+      'react-dom': 'ReactDOM',
+      sweetalert2: 'swal',
+    }),
+  }
 }
 
 function expandExternalsConfig(compactConfig) {


### PR DESCRIPTION
Related to issue https://github.com/sweetalert2/sweetalert2-react-content/issues/12#issuecomment-371309111

I'm not sure if this is good since the non-minified build is majorly bloated from webpack.. heres a sample:

<details>

```js

(function webpackUniversalModuleDefinition(root, factory) {
	if(typeof exports === 'object' && typeof module === 'object')
		module.exports = factory(require("react"), require("react-dom"), require("sweetalert2"));
	else if(typeof define === 'function' && define.amd)
		define(["react", "react-dom", "sweetalert2"], factory);
	else if(typeof exports === 'object')
		exports["sweetalert2ReactContent"] = factory(require("react"), require("react-dom"), require("sweetalert2"));
	else
		root["sweetalert2ReactContent"] = factory(root["React"], root["ReactDOM"], root["swal"]);
})(window, function(__WEBPACK_EXTERNAL_MODULE_react__, __WEBPACK_EXTERNAL_MODULE_react_dom__, __WEBPACK_EXTERNAL_MODULE_sweetalert2__) {
return /******/ (function(modules) { // webpackBootstrap
/******/ 	// The module cache
/******/ 	var installedModules = {};
/******/
/******/ 	// The require function
/******/ 	function __webpack_require__(moduleId) {
/******/
/******/ 		// Check if module is in cache
/******/ 		if(installedModules[moduleId]) {
/******/ 			return installedModules[moduleId].exports;
/******/ 		}
/******/ 		// Create a new module (and put it into the cache)
/******/ 		var module = installedModules[moduleId] = {
/******/ 			i: moduleId,
/******/ 			l: false,
/******/ 			exports: {}
/******/ 		};
/******/
/******/ 		// Execute the module function
/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
/******/
/******/ 		// Flag the module as loaded
/******/ 		module.l = true;
/******/
/******/ 		// Return the exports of the module
/******/ 		return module.exports;
/******/ 	}
/******/
/******/
/******/ 	// expose the modules object (__webpack_modules__)
/******/ 	__webpack_require__.m = modules;
/******/
/******/ 	// expose the module cache
/******/ 	__webpack_require__.c = installedModules;
/******/
/******/ 	// define getter function for harmony exports
/******/ 	__webpack_require__.d = function(exports, name, getter) {
/******/ 		if(!__webpack_require__.o(exports, name)) {
/******/ 			Object.defineProperty(exports, name, {
/******/ 				configurable: false,
/******/ 				enumerable: true,
/******/ 				get: getter
/******/ 			});
/******/ 		}
/******/ 	};
/******/
/******/ 	// define __esModule on exports
/******/ 	__webpack_require__.r = function(exports) {
/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
/******/ 	};
/******/
/******/ 	// getDefaultExport function for compatibility with non-harmony modules
/******/ 	__webpack_require__.n = function(module) {
/******/ 		var getter = module && module.__esModule ?
/******/ 			function getDefault() { return module['default']; } :
/******/ 			function getModuleExports() { return module; };
/******/ 		__webpack_require__.d(getter, 'a', getter);
/******/ 		return getter;
/******/ 	};
/******/
/******/ 	// Object.prototype.hasOwnProperty.call
/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
/******/
/******/ 	// __webpack_public_path__
/******/ 	__webpack_require__.p = "";
/******/
/******/
/******/ 	// Load entry module and return exports
/******/ 	return __webpack_require__(__webpack_require__.s = 0);
/******/ })
/************************************************************************/
/******/ ({

/***/ "./src/mounts.js":
/*!***********************!*\
  !*** ./src/mounts.js ***!
  \***********************/
/*! no static exports found */
/***/ (function(module, exports, __webpack_require__) {

"use strict";


Object.defineProperty(exports, "__esModule", {
  value: true
});
var mounts = exports.mounts = [{
  key: 'title',
  getter: function getter(swal) {
    return swal.getTitle();
  }
}, {
  key: 'html',
  getter: function getter(swal) {
    return swal.getContent();
  }
}, {
  key: 'confirmButtonText',
  getter: function getter(swal) {
    return swal.getConfirmButton();
  }
}, {
  key: 'cancelButtonText',
  getter: function getter(swal) {
    return swal.getCancelButton();
  }
}, {
  key: 'footer',
  getter: function getter(swal) {
    return swal.getFooter();
  }
}];

/***/ }),

/***/ "./src/sweetalert2-react-content.js":
/*!******************************************!*\
  !*** ./src/sweetalert2-react-content.js ***!
  \******************************************/
/*! no static exports found */
/***/ (function(module, exports, __webpack_require__) {

"use strict";


Object.defineProperty(exports, "__esModule", {
  value: true
});
exports.default = withReactContent;

var _sweetalert = __webpack_require__(/*! sweetalert2 */ "sweetalert2");

var _sweetalert2 = _interopRequireDefault(_sweetalert);

var _react = __webpack_require__(/*! react */ "react");

var _react2 = _interopRequireDefault(_react);

var _reactDom = __webpack_require__(/*! react-dom */ "react-dom");

var _reactDom2 = _interopRequireDefault(_reactDom);

var _mounts = __webpack_require__(/*! ./mounts */ "./src/mounts.js");

function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

var noop = function noop() {};

function withReactContent() {
  var parentSwal = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : _sweetalert2.default;

  var argsToParams = function argsToParams(args) {
    if (_react2.default.isValidElement(args[0]) || _react2.default.isValidElement(args[1])) {
      var params = {};['title', 'html', 'type'].forEach(function (name, index) {
        if (args[index] !== undefined) {
          params[name] = args[index];
        }
      });
      return params;
    } else {
      return parentSwal.argsToParams(args);
    }
  };

  var fn = function fn() {
    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
      args[_key] = arguments[_key];
    }

    var params = Object.assign({}, argsToParams(args)); // safe to mutate this

    params.onOpen = params.onOpen || noop;
    params.onClose = params.onClose || noop;

    var _loop = function _loop(key, getter) {
      if (_react2.default.isValidElement(params[key])) {
        var reactElement = params[key];
        params[key] = ' ';

        var domElement = void 0;

        var childOnOpen = params.onOpen;
        params.onOpen = function () {
          domElement = getter(parentSwal);
          _reactDom2.default.render(reactElement, domElement);
          childOnOpen();
        };

        var childOnClose = params.onClose;
        params.onClose = function () {
          childOnClose();
          _reactDom2.default.unmountComponentAtNode(domElement);
        };
      }
    };

    var _iteratorNormalCompletion = true;
    var _didIteratorError = false;
    var _iteratorError = undefined;

    try {
      for (var _iterator = _mounts.mounts[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
        var _ref = _step.value;
        var key = _ref.key;
        var getter = _ref.getter;

        _loop(key, getter);
      }
    } catch (err) {
      _didIteratorError = true;
      _iteratorError = err;
    } finally {
      try {
        if (!_iteratorNormalCompletion && _iterator.return) {
          _iterator.return();
        }
      } finally {
        if (_didIteratorError) {
          throw _iteratorError;
        }
      }
    }

    return parentSwal(params);
  };

  return Object.assign(fn, parentSwal, { argsToParams: argsToParams });
}

/***/ }),

/***/ 0:
/*!************************************************!*\
  !*** multi ./src/sweetalert2-react-content.js ***!
  \************************************************/
/*! no static exports found */
/***/ (function(module, exports, __webpack_require__) {

module.exports = __webpack_require__(/*! C:\Users\Matt\Documents\dev\sweetalert2-react-content\src\sweetalert2-react-content.js */"./src/sweetalert2-react-content.js");


/***/ }),

/***/ "react":
/*!**************************************************************************************!*\
  !*** external {"commonjs":"react","commonjs2":"react","amd":"react","root":"React"} ***!
  \**************************************************************************************/
/*! no static exports found */
/***/ (function(module, exports) {

module.exports = __WEBPACK_EXTERNAL_MODULE_react__;

/***/ }),

/***/ "react-dom":
/*!*****************************************************************************************************!*\
  !*** external {"commonjs":"react-dom","commonjs2":"react-dom","amd":"react-dom","root":"ReactDOM"} ***!
  \*****************************************************************************************************/
/*! no static exports found */
/***/ (function(module, exports) {

module.exports = __WEBPACK_EXTERNAL_MODULE_react_dom__;

/***/ }),

/***/ "sweetalert2":
/*!*******************************************************************************************************!*\
  !*** external {"commonjs":"sweetalert2","commonjs2":"sweetalert2","amd":"sweetalert2","root":"swal"} ***!
  \*******************************************************************************************************/
/*! no static exports found */
/***/ (function(module, exports) {

module.exports = __WEBPACK_EXTERNAL_MODULE_sweetalert2__;

/***/ })

/******/ });
});
//# sourceMappingURL=sweetalert2-react-content.umd.js.map

```

</details>