### PR TITLE
Add official keyword to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # sweetalert2-react-content
 
+Official [SweetAlert2](https://sweetalert2.github.io) integration for React
+
 [![Build Status](https://travis-ci.org/sweetalert2/sweetalert2-react-content.svg?branch=master)](https://travis-ci.org/sweetalert2/sweetalert2-react-content)
 [![Coverage Status](https://coveralls.io/repos/github/sweetalert2/sweetalert2-react-content/badge.svg?branch=master)](https://coveralls.io/github/sweetalert2/sweetalert2-react-content?branch=master)
 [![npm version](https://badge.fury.io/js/sweetalert2-react-content.svg)](https://www.npmjs.com/packages/sweetalert2-react-content)


### PR DESCRIPTION
Because there's a ton of wrappers out there, let's label this one as "official".

PS. https://sweetalert2.github.io/#frameworks-integrations :tada: 