### PR TITLE
chore(ci): only run release stage if on master *and it's a push*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
 stages:
   - name: test
   - name: release
-    if: branch = master
+    if: branch = master and type = push
 jobs:
   include:
     - stage: test


### PR DESCRIPTION
I found that "PR" builds actually merge the PR branch into master, not the other way around, so this is to prevent the Release stage from running for PRs

testing what happens with this