### PR TITLE
chore(travis): google-chrome: latest -> chrome: stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js: node
 sudo: true
 addons:
-  google-chrome: latest
+  chrome: stable
 stages:
   - name: test
   - name: release


### PR DESCRIPTION
It looks like for some weird reason `google-chrome: latest` is stuck on v62 while `chrome: stable` works as expected and installs Chrome 65.

The same as https://github.com/sweetalert2/sweetalert2/pull/1029