### PR TITLE
chore(travis): do no send emails about successful builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ jobs:
       script: npm test && cat ./coverage/lcov.info | coveralls
     - stage: release
       script: npm run build && semantic-release
+notifications:
+  email:
+    on_success: never


### PR DESCRIPTION
Prevent noise in the inbox, do not send unnecessary emails about CI builds.

Docs: https://docs.travis-ci.com/user/notifications/#Configuring-email-notifications