### PR TITLE
fix(dom): mount html content inside element used for html content

### DIFF
--- a/src/mounts.js
+++ b/src/mounts.js
@@ -5,7 +5,7 @@ export const mounts = [
   },
   {
     key: 'html',
-    getter: swal => swal.getContent(),
+    getter: swal => swal.getContent().querySelector('#swal2-content'),
   },
   {
     key: 'confirmButtonText',

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -27,7 +27,7 @@ describe('integration', () => {
       footer: <span>footer</span>,
       onOpen: () => {
         expect(MySwal.getTitle().innerHTML).toEqual('<span>title</span>')
-        expect(MySwal.getContent().innerHTML).toEqual('<span>html</span>')
+        expect(getSwalContentContent().innerHTML).toEqual('<span>html</span>')
         expect(MySwal.getConfirmButton().innerHTML).toEqual(
           '<span>confirmButtonText</span>',
         )
@@ -70,7 +70,7 @@ describe('integration', () => {
     const swal = MySwal.fire(<span>title</span>, <span>html</span>, 'info')
     await timeout(100)
     expect(MySwal.getTitle().innerHTML).toEqual('<span>title</span>')
-    expect(MySwal.getContent().innerHTML).toEqual('<span>html</span>')
+    expect(getSwalContentContent().innerHTML).toEqual('<span>html</span>')
     expect(getVisibleSwalIconNames()).toEqual(['info'])
     MySwal.clickConfirm()
     await swal


### PR DESCRIPTION
BREAKING CHANGE:The react element given as `html` is now mounted in a child element of the element it was mounted in before

Note that those previous and current elements have different styles, particularly `text-align` which was `left` in the previous and is `center` in the current.

The problem was that the previously used element is also used by sweetalert2 for rendering any input element. If a swal was fired with a React component for `html` and something for `input`, the mounting of the React component would remove/destroy the input element.

Some maintenance should be done with the current 1.x version before merging this and starting 2.x