### PR TITLE
Support sweetalert2 v8

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following options can be React elements:
 ## Installation
 
 ```bash
-npm install --save sweetalert2@^7.18.0 sweetalert2-react-content
+npm install --save sweetalert2 sweetalert2-react-content
 ```
 
 ## Usage Example

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "peerDependencies": {
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "sweetalert2": "^7.18.0 || ^8.2.2"
+    "sweetalert2": "^7.18.0 || ^8.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",
@@ -71,7 +71,7 @@
     "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-terser": "^4.0.4",
     "semantic-release": "^15.0.0",
-    "sweetalert2": "^8.2.2",
+    "sweetalert2": "^8.3.0",
     "tslint": "^5.9.1",
     "typescript": "^3.1.3",
     "zenflow-lint-js": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-terser": "^4.0.4",
     "semantic-release": "^15.0.0",
-    "sweetalert2": "^7.18.0",
+    "sweetalert2": "^8.2.2",
     "tslint": "^5.9.1",
     "typescript": "^3.1.3",
     "zenflow-lint-js": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "peerDependencies": {
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "sweetalert2": "^7.18.0"
+    "sweetalert2": "^7.18.0 || ^8.2.2"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom'
 import { mounts } from './mounts'
 
 const noop = () => {}
+const error = message => new Error(`sweetalert2-react-content: ${message}`)
 
 export default function withReactContent(ParentSwal) {
   return class extends ParentSwal {
@@ -48,6 +49,11 @@ export default function withReactContent(ParentSwal) {
       })
 
       return super._main(params)
+    }
+    update() {
+      throw error(
+        'Swal.update() is not yet supported. See https://github.com/sweetalert2/sweetalert2-react-content/issues/73',
+      )
     }
   }
 }

--- a/test/util/swalUtil.js
+++ b/test/util/swalUtil.js
@@ -1,8 +1,7 @@
 import Swal from 'sweetalert2/dist/sweetalert2' // js-only, no styles
 
 async function cleanSwalState() {
-  Swal.resetDefaults()
-  await Swal({
+  await Swal.fire({
     animation: false,
     title: 'clear',
     onOpen: () => Swal.clickConfirm(),


### PR DESCRIPTION
Closes #66

No changes to the source code were actually needed to get the tests passing; just needed to stop some removed features in the `cleanSwalState` test utility function.

Note that this PR keeps support for v7, but in the next major release I think we should drop it.

We should merge this with commit message `feat(package): support sweetalert2 v8`. The changes are backwards-compatible so we can make it a minor release.

Just one more commit to add: since the new `Swal.update` static method is not supported yet, I think calling it should throw an error. @limonte any thoughts?