### PR TITLE
fix(changelog): add missing changelog entry for v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.0.2](https://github.com/sweetalert2/sweetalert2-react-content/compare/v1.0.1...v1.0.2) (2019-02-20)
+
+
+### Bug Fixes
+
+* **banner:** fix version number in banner comment, closes [#48](https://github.com/sweetalert2/sweetalert2-react-content/issues/48) ([#74](https://github.com/sweetalert2/sweetalert2-react-content/issues/74)) ([a30f59b](https://github.com/sweetalert2/sweetalert2-react-content/commit/))
+
 ## [1.0.1](https://github.com/sweetalert2/sweetalert2-react-content/compare/v1.0.0...v1.0.1) (2018-06-18)
 
 


### PR DESCRIPTION
Not technically a "fix" according to the [commit guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) but with PR #74 I accidentally removed the `release-notes-generator` semantic-release plugin (which is why the changelog entry for v1.0.2 is missing) and I want to make sure #76 fixed it