### PR TITLE
docs: Add closeButtonHtml to list of options that can be React elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The following options can be React elements:
  - confirmButtonText
  - cancelButtonText
  - footer
+ - closeButtonHtml
 
 ## Installation
 


### PR DESCRIPTION
README documentation updates missed in PR #121 